### PR TITLE
swarm: Feature: Eigene Media-Items in My Media erstellen und löschen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -447,6 +447,33 @@ export default function App() {
     await loadMyMedia();
   };
 
+  const handleDeleteMyMedia = async (item: MediaItem): Promise<void> => {
+    if (!userId || item.owner_id !== userId) {
+      return;
+    }
+
+    const shouldDelete = window.confirm(
+      `Item ${item.label ?? `#${item.id}`} wirklich loeschen?`
+    );
+
+    if (!shouldDelete) {
+      return;
+    }
+
+    setAppError(null);
+    const { error } = await supabase.from("media_items").delete().eq("id", item.id);
+
+    if (error) {
+      setAppError(error.message);
+      return;
+    }
+
+    setMyMediaItems((previous) => previous.filter((entry) => entry.id !== item.id));
+    if (selectedMyMediaId === item.id) {
+      setSelectedMyMediaId(null);
+    }
+  };
+
   if (!session) {
     return (
       <main>
@@ -543,6 +570,11 @@ export default function App() {
 	              >
 	                Auswaehlen {item.label ?? `#${item.id}`} ({item.kind})
 	              </button>
+	              {item.owner_id === userId ? (
+	                <button type="button" onClick={() => void handleDeleteMyMedia(item)}>
+	                  Loeschen
+	                </button>
+	              ) : null}
 	              <div>Unlock ab: {item.unlock_min_messages}</div>
 	              {item.kind === "image" ? (
 	                item.url ? (


### PR DESCRIPTION
## Swarm Run Summary
- Run ID: `20260214-080154-3e273051`
- Artifacts: `artifacts/runs/20260214-080154-3e273051`
- Issue: `https://github.com/paulgrotzke/unlock-poc/issues/3` (#3: Feature: Eigene Media-Items in My Media erstellen und löschen)

## Task Plan
- task-001: Map current My Media data flow and ownership rules
- task-002: Add create-item form with conditional validation and submit (depends on: task-001)
- task-003: Add delete action for own items with safety confirm (depends on: task-002)
- task-004: Run targeted regression checks for existing media workflows (depends on: task-003)

## Worker Handoffs
- task-001: Skill loaded. Next I’ll trace My Media hooks/services and ownership/error logic in `src`.
- task-002: Patch had a context mismatch; I’ll re-open exact sections and apply a focused patch cleanly.
- task-003: Delete handler and owner-gated control are in place; I’ll run a build to verify task-003 changes compile.
- task-004: I confirmed this repo expects manual browser verification with Supabase; next I’ll check local readiness (`.env`, dep...

## Release Verification
- Overall status: passed
- Commands configured: 2
- Commands executed: 2
- Duration: 3.5s
- 1. `npm ci` -> passed (1.5s)
- 2. `npm run build` -> passed (2.0s)